### PR TITLE
Improve support for vue files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 | `conver` | Conversion type, such as conversion to scss syntax | string | scss | scss |
 | `autoprefixer` | Whether or not to automatically add a prefix, stylus will automatically add prefixes when converting stylus grammars. `@keyframes` | boolean | true / false | true |
 | `isSignComment` | Whether to change a single-line comment to a multiple-line comment, because stylus does not get a single-line comment when converting ast, if you want to keep a comment it can only be converted to a multi-line comment. | boolean | true / false | false |
+| `indentVueStyleBlock` | Indent the entire style block of a vue file with a certain amount of spaces. | number | number | 0 |
 
 ### cli options
 
@@ -61,6 +62,7 @@
 | `--directory` | `-d` | Whether the input and output paths are directories | yes / no | no |
 | `--autoprefixer` | `-p` | Whether to add a prefix | yes / no | yes |
 | `--singlecomments` | `-s` | Whether to change a single-line comment to a multiple-line comment, because stylus does not get a single-line comment when converting ast, if you want to keep a comment it can only be converted to a multi-line comment. | yes / no | no |
+| `--indentVueStyleBlock` | `-v` | Indent the entire style block of a vue file with a certain amount of spaces. | number | 0 |
 
 ## Use examples
 
@@ -72,7 +74,7 @@ npm install -g stylus-converter
 stylus-conver -i test.styl -o test.scss
 
 // Run the cli conversion directory
-// cd your project 
+// cd your project
 mv src src-temp
 stylus-conver -d yes -i src-temp -o src
 ```

--- a/bin/conver.js
+++ b/bin/conver.js
@@ -18,6 +18,7 @@ function handleOptions () {
   const directory = argv.d || argv.directory || 'no'
   const autoprefixer =  argv.p || argv.autoprefixer || 'yes'
   const isSignComment = argv.s || argv.singlecomments || 'no'
+  const indentVueStyleBlock =  argv.v || argv.indentVueStyleBlock || 0
   if (!input) throw new Error('The input parameter cannot be empty.')
   if (!output) throw new Error('The output parameter cannot be empty.')
   if (quote !== 'single' && quote !== 'dobule') throw new Error('The quote parameter has a problem, it can only be single or double.')
@@ -31,7 +32,8 @@ function handleOptions () {
     conver,
     directory: directory === 'yes',
     autoprefixer: autoprefixer === 'yes',
-    isSignComment: isSignComment === 'yes'
+    isSignComment: isSignComment === 'yes',
+    indentVueStyleBlock: Number(indentVueStyleBlock),
   }, time => {
     spinner.succeed('Conversion completed and time spent ' + time + ' ms.')
   })
@@ -46,5 +48,6 @@ program
     .option('-d, --directory', 'Is directory type')
     .option('-p, --autoprefixer', 'Whether to add a prefix')
     .option('-s, --singlecomments ', 'Change single-line comments to multi-line comments')
+    .option('-v, --indentVueStyleBlock ', 'Indent the entire style block of a vue file with a certain amount of spaces.')
     .action(handleOptions)
     .parse(process.argv);

--- a/bin/convertVueFile.js
+++ b/bin/convertVueFile.js
@@ -1,0 +1,21 @@
+const converter = require('../lib')
+
+function convertVueFile(vueTemplate, options) {
+  const styleRegEx = /<style(.*)>((\n|.)*)<\/style>/
+  const matches = vueTemplate.match(styleRegEx)
+  if (Array.isArray(matches) && matches.length >= 2) {
+    if(matches[1].includes('stylus')) {
+      let style = matches[2]
+      if (style.trim()) {
+        style = converter(style, options)
+      }
+      const isScoped = matches[1].includes('scoped')
+      const styleText = `<style lang="scss"${isScoped ? ' scoped' : ''}>${style}</style>`
+      return vueTemplate.replace(styleRegEx, styleText)
+    }
+  }
+  return vueTemplate;
+}
+
+
+module.exports = convertVueFile;

--- a/bin/file.js
+++ b/bin/file.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const converter = require('../lib')
+const convertVueFile = require('./convertVueFile')
 
 let callLen = 0
 let startTime = 0
@@ -50,13 +51,7 @@ function handleFile (input, output, options, callback) {
         outputPath = output.replace(/\.styl$/, '.' + options.conver)
       } else {
         //处理 vue 文件
-        const styleReg = /<style.*>((\n|.)*)<\/style>/
-        const matchs = result.match(styleReg)
-        if (Array.isArray(matchs) && matchs.length >= 2) {
-          const text = converter(matchs[1], options)
-          const styleText = `<style lang="scss">${text}</style>`
-          result = result.replace(styleReg, styleText)
-        }
+        result = convertVueFile(result, options);
       }
       fs.writeFile(outputPath, result, err => {
         if (err) throw err

--- a/doc/zh-cn.md
+++ b/doc/zh-cn.md
@@ -49,6 +49,7 @@
 | `conver` | 转换类型，例如转换成 scss 语法 | string | scss | scss |
 | `autoprefixer` | 是否自动添加前缀，stylus 在转换 css 语法的时候，有些语法会自动添加前缀例如 `@keyframes` | boolean | true / false | true |
 | `isSignComment` | 是否将单行注释更改为多行注释，因为手写笔在转换ast时未获得单行注释，如果您想保留注释，则只能将其转换为多行注释。 | boolean | true / false | false |
+| `indentVueStyleBlock` |  | number | number | 0 |
 
 ### cli 配置
 
@@ -61,6 +62,7 @@
 | `--directory` | `-d` | 输入和输出路径是否是个目录 | yes / no | no |
 | `--autoprefixer` | `-p` | 是否添加前缀 | yes / no | yes |
 | `--singlecomments` | `-s` | 是否将单行注释更改为多行注释，因为手写笔在转换ast时未获得单行注释，如果您想保留注释，则只能将其转换为多行注释。 | yes / no | no |
+| `--indentVueStyleBlock` | `-v` |  | number | 0 |
 
 ## 使用示例
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -659,6 +659,8 @@ function visitor(ast, options) {
   conver = options.conver;
   autoprefixer = options.autoprefixer;
   var result = visitNodes(ast.nodes) || '';
+  var indentation = ' '.repeat(options.indentVueStyleBlock);
+  result = result.replace(/(.*\S.*)/g, indentation + '$1');
   oldLineno = 1;
   FUNCTION_PARAMS = [];
   OBJECT_KEY_LIST = [];

--- a/src/visitor/index.js
+++ b/src/visitor/index.js
@@ -577,7 +577,9 @@ export default function visitor (ast, options) {
   quote = options.quote
   conver = options.conver
   autoprefixer = options.autoprefixer
-  const result = visitNodes(ast.nodes) || ''
+  let result = visitNodes(ast.nodes) || ''
+  const indentation = ' '.repeat(options.indentVueStyleBlock)
+  result = result.replace(/(.*\S.*)/g, `${indentation}$1`);
   oldLineno = 1
   FUNCTION_PARAMS = []
   OBJECT_KEY_LIST = []

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const converter = require('../lib')
 const expect = require('chai').expect
+const convertVueFile = require('../bin/convertVueFile')
 
 function getPath (address) {
   return path.resolve(__dirname, address)
@@ -345,6 +346,64 @@ describe('测试 @Import', () => {
       const result = res.toString()
       const scss = converter(result)
       fs.readFile(getPath('./scss/import.scss'), (err, sres) => {
+        if (err) return
+        const toText = sres.toString()
+        expect(scss).to.be.equal(toText)
+        done()
+      })
+    })
+  })
+})
+
+describe('A vue file', () => {
+  it('should be converted correctly', done => {
+    fs.readFile(getPath('./vue/stylus/basic.vue'), (err, res) => {
+      if (err) return
+      const result = res.toString()
+      const scss = convertVueFile(result)
+      fs.readFile(getPath('./vue/scss/basic.vue'), (err, sres) => {
+        if (err) return
+        const toText = sres.toString()
+        expect(scss).to.be.equal(toText)
+        done()
+      })
+    })
+  })
+
+  it('should retain it\'s style scoped attribute', done => {
+    fs.readFile(getPath('./vue/stylus/scoped.vue'), (err, res) => {
+      if (err) return
+      const result = res.toString()
+      const scss = convertVueFile(result)
+      fs.readFile(getPath('./vue/scss/scoped.vue'), (err, sres) => {
+        if (err) return
+        const toText = sres.toString()
+        expect(scss).to.be.equal(toText)
+        done()
+      })
+    })
+  })
+
+  it('should handle indentation of the style block ', done => {
+    fs.readFile(getPath('./vue/stylus/indented.vue'), (err, res) => {
+      if (err) return
+      const result = res.toString()
+      const scss = convertVueFile(result, { indentVueStyleBlock: 2 });
+      fs.readFile(getPath('./vue/scss/indented.vue'), (err, sres) => {
+        if (err) return
+        const toText = sres.toString()
+        expect(scss).to.be.equal(toText)
+        done()
+      })
+    })
+  })
+
+  it('should handle handle empty style blocks', done => {
+    fs.readFile(getPath('./vue/stylus/empty.vue'), (err, res) => {
+      if (err) return
+      const result = res.toString()
+      const scss = convertVueFile(result, { indentVueStyleBlock: 2 });
+      fs.readFile(getPath('./vue/scss/empty.vue'), (err, sres) => {
         if (err) return
         const toText = sres.toString()
         expect(scss).to.be.equal(toText)

--- a/test/vue/scss/basic.vue
+++ b/test/vue/scss/basic.vue
@@ -1,0 +1,13 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="scss">
+div {
+  color: white;
+}
+</style>

--- a/test/vue/scss/empty.vue
+++ b/test/vue/scss/empty.vue
@@ -1,0 +1,9 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="scss"></style>

--- a/test/vue/scss/indented.vue
+++ b/test/vue/scss/indented.vue
@@ -1,0 +1,13 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="scss">
+  div {
+    color: white;
+  }
+</style>

--- a/test/vue/scss/scoped.vue
+++ b/test/vue/scss/scoped.vue
@@ -1,0 +1,13 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="scss" scoped>
+div {
+  color: white;
+}
+</style>

--- a/test/vue/stylus/basic.vue
+++ b/test/vue/stylus/basic.vue
@@ -1,0 +1,12 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="stylus">
+div
+  color: white
+</style>

--- a/test/vue/stylus/empty.vue
+++ b/test/vue/stylus/empty.vue
@@ -1,0 +1,9 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="stylus"></style>

--- a/test/vue/stylus/indented.vue
+++ b/test/vue/stylus/indented.vue
@@ -1,0 +1,12 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="stylus">
+  div
+    color: white
+</style>

--- a/test/vue/stylus/scoped.vue
+++ b/test/vue/stylus/scoped.vue
@@ -1,0 +1,12 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="stylus" scoped>
+div
+  color: white
+</style>


### PR DESCRIPTION
Thanks for this awesome tool! I ran into some issue while trying to use this on vue files so I added a few things. 

- Added an `indentVueStyleBlock` param that indents vue style blocks, a common pattern. Safely defaults to no indent.
- Does not attempt to convert style blocks unless they have the style `lang="stylus"` attribute. 
- Retains the `scoped` attribute.

One TODO, is to add proper descriptions to the zh-cn README.

