### PR TITLE
feat: 添加深度作用选择器的替换

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -857,6 +857,7 @@ function visitor(ast, options, globalVariableList, globalMixinList) {
   var result = visitNodes(ast.nodes) || '';
   var indentation = ' '.repeat(options.indentVueStyleBlock);
   result = result.replace(/(.*\S.*)/g, indentation + '$1');
+  result = result.replace(/(.*)>>>(.*)/g, '$1/deep/$2');
   oldLineno = 1;
   FUNCTION_PARAMS = [];
   OBJECT_KEY_LIST = [];

--- a/src/visitor/index.js
+++ b/src/visitor/index.js
@@ -753,6 +753,7 @@ export default function visitor(ast, options, globalVariableList, globalMixinLis
   let result = visitNodes(ast.nodes) || ''
   const indentation = ' '.repeat(options.indentVueStyleBlock)
   result = result.replace(/(.*\S.*)/g, `${indentation}$1`);
+  result = result.replace(/(.*)>>>(.*)/g, `$1/deep/$2`)
   oldLineno = 1
   FUNCTION_PARAMS = []
   OBJECT_KEY_LIST = []

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -370,6 +370,20 @@ describe('A vue file', () => {
     })
   })
 
+  it('should be converted deep selectors', done => {
+    fs.readFile(getPath('./vue/stylus/deep.vue'), (err, res) => {
+      if (err) return
+      const result = res.toString()
+      const scss = convertVueFile(result)
+      fs.readFile(getPath('./vue/scss/deep.vue'), (err, sres) => {
+        if (err) return
+        const toText = sres.toString()
+        expect(scss).to.be.equal(toText)
+        done()
+      })
+    })
+  })
+
   it('should retain it\'s style scoped attribute', done => {
     fs.readFile(getPath('./vue/stylus/scoped.vue'), (err, res) => {
       if (err) return

--- a/test/vue/scss/deep.vue
+++ b/test/vue/scss/deep.vue
@@ -1,0 +1,15 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="scss" scoped>
+div {
+  /deep/ div {
+    color: white;
+  }
+}
+</style>

--- a/test/vue/stylus/deep.vue
+++ b/test/vue/stylus/deep.vue
@@ -1,0 +1,13 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+  export default {}
+</script>
+
+<style lang="stylus" scoped>
+div
+  >>> div
+    color: white
+</style>


### PR DESCRIPTION
在vue中
当 <style> 标签有 scoped 属性时，选择器穿透需要用到深度作用选择器
`stylus`和`css`中使用的是`>>>`
 `sass`和`less`中使用的`/deep/`
因此加了个正则将`>>>`替换成`/deep/`
[深度作用选择器](https://vue-loader.vuejs.org/zh/guide/scoped-css.html#%E6%B7%B1%E5%BA%A6%E4%BD%9C%E7%94%A8%E9%80%89%E6%8B%A9%E5%99%A8)