### PR TITLE
修复无法匹配Windows下CRLF（\r\n）换行符

### DIFF
--- a/bin/convertVueFile.js
+++ b/bin/convertVueFile.js
@@ -2,7 +2,7 @@ const { converter } = require('../lib')
 
 function convertVueFile(vueTemplate, options) {
   let newVueTemplate = vueTemplate;
-  const styleRegEx = /<style(.*)>((\n|.)*?)<\/style>/g;
+  const styleRegEx = /<style(.*)>([\w\W]*?)<\/style>/g;
   let match;
   while ((match = styleRegEx.exec(newVueTemplate)) !== null) {
     if (match[1].includes('stylus')) {


### PR DESCRIPTION
(\n|.)无法匹配出Windows下CRLF（\r\n）换行符，导致一些vue文件没被转换，换成[\w\W]可以匹配所有字符，但不知是否会对余下转换流程造成影响